### PR TITLE
Give data array to hit so it's easier to manipulate later

### DIFF
--- a/src/Hit/Hit.php
+++ b/src/Hit/Hit.php
@@ -10,13 +10,17 @@ final class Hit
 
     private string $clientId;
 
-    private string $payload;
+    /** @var array<string, scalar> */
+    private array $data;
 
-    public function __construct(string $propertyId, string $clientId, string $payload)
+    /**
+     * @param array<string, scalar> $data
+     */
+    public function __construct(string $propertyId, string $clientId, array $data)
     {
         $this->propertyId = $propertyId;
         $this->clientId = $clientId;
-        $this->payload = $payload;
+        $this->data = $data;
     }
 
     public function getPropertyId(): string
@@ -29,9 +33,31 @@ final class Hit
         return $this->clientId;
     }
 
+    /**
+     * @return array<string, scalar>
+     */
+    public function getData(): array
+    {
+        return $this->data;
+    }
+
+    /**
+     * The payload is the string representation of the hit which is what you send to Google Analytics
+     */
     public function getPayload(): string
     {
-        return $this->payload;
+        $str = '';
+
+        foreach ($this->getData() as $key => $value) {
+            // if you cast false to string it returns '' (empty string) and not '0'
+            if (is_bool($value)) {
+                $value = (int) $value;
+            }
+
+            $str .= $key . '=' . rawurlencode((string) $value) . '&';
+        }
+
+        return rtrim($str, '&');
     }
 
     public function __toString(): string

--- a/src/Hit/HitBuilder.php
+++ b/src/Hit/HitBuilder.php
@@ -34,20 +34,7 @@ final class HitBuilder implements HitBuilderInterface
         $data = $this->data;
         $data['tid'] = $propertyId;
 
-        $str = '';
-
-        foreach ($data as $key => $value) {
-            // if you cast false to string it returns '' (empty string) and not '0'
-            if (is_bool($value) && false === $value) {
-                $value = '0';
-            }
-
-            $str .= $key . '=' . rawurlencode((string) $value) . '&';
-        }
-
-        $str = rtrim($str, '&');
-
-        return new Hit($propertyId, (string) $this->getClientId(), $str);
+        return new Hit($propertyId, (string) $this->getClientId(), $data);
     }
 
     /**

--- a/tests/Client/ClientTest.php
+++ b/tests/Client/ClientTest.php
@@ -56,7 +56,7 @@ final class ClientTest extends TestCase
         $purchaseEvent->applyTo($hitBuilder);
 
         /** @var DebugResponse $response */
-        $response = $client->sendHit($hitBuilder->getHit('UA-123414-5')->getPayload());
+        $response = $client->sendHit((string) $hitBuilder->getHit('UA-123414-5'));
 
         self::assertTrue($response->wasValid(), implode("\n", $response->getErrors()));
     }

--- a/tests/Hit/HitTest.php
+++ b/tests/Hit/HitTest.php
@@ -16,12 +16,12 @@ class HitTest extends TestCase
      */
     public function it_returns_correct_values(): void
     {
-        $payload = 'v=1';
+        $data = ['v' => '1'];
 
-        $obj = new Hit('property_id', 'client_id', $payload);
+        $obj = new Hit('property_id', 'client_id', $data);
         self::assertSame('property_id', $obj->getPropertyId());
         self::assertSame('client_id', $obj->getClientId());
-        self::assertSame($payload, $obj->getPayload());
-        self::assertSame($payload, (string) $obj);
+        self::assertSame($data, $obj->getData());
+        self::assertSame('v=1', (string) $obj);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -13,6 +13,6 @@ abstract class TestCase extends BaseTestCase
     {
         $expectedQuery = trim(preg_replace('/[\t\n]+/', '', $expectedQuery));
 
-        self::assertSame($expectedQuery, $hit->getPayload());
+        self::assertSame($expectedQuery, (string) $hit);
     }
 }


### PR DESCRIPTION
This PR adds the data array to the `Hit` class. This makes it far easier to manipulate the data after the data has been transferred to the `Hit`.

This is also a breaking change since the signature of `Hit`s constructor is changed.