### PR TITLE
Add queue time parameter to hits where qt > 0

### DIFF
--- a/src/Hit/HitBuilderInterface.php
+++ b/src/Hit/HitBuilderInterface.php
@@ -9,6 +9,8 @@ use Setono\GoogleAnalyticsMeasurementProtocol\Response\ResponseInterface;
 
 interface HitBuilderInterface
 {
+    public const PARAMETER_QUEUE_TIME = 'qt';
+
     public const HIT_TYPE_PAGEVIEW = 'pageview';
 
     public const HIT_TYPE_SCREENVIEW = 'screenview';

--- a/tests/Hit/HitTest.php
+++ b/tests/Hit/HitTest.php
@@ -24,4 +24,19 @@ class HitTest extends TestCase
         self::assertSame($data, $obj->getData());
         self::assertSame('v=1', (string) $obj);
     }
+
+    /**
+     * @test
+     */
+    public function it_calculates_queue_time(): void
+    {
+        $data = ['v' => '1'];
+
+        $then = \DateTimeImmutable::createFromFormat('Y-m-d H:i:s.u', '2021-09-25 12:03:40.123456');
+        $now = \DateTimeImmutable::createFromFormat('Y-m-d H:i:s.u', '2021-09-27 14:05:41.456789');
+        $qt = 180_121_334; // calculated manually from the two timestamps above
+
+        $obj = new Hit('property_id', 'client_id', $data, $then);
+        self::assertSame('v=1&qt=' . $qt, $obj->getPayload($now));
+    }
 }


### PR DESCRIPTION
This PR adds the [queue time parameter](https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#qt) to hits where the qt is calculated to be above 0