### PR TITLE
Fix encoded HTML in title

### DIFF
--- a/src/Response/Adapter/SymfonyResponseAdapter.php
+++ b/src/Response/Adapter/SymfonyResponseAdapter.php
@@ -27,7 +27,7 @@ final class SymfonyResponseAdapter implements ResponseInterface
             return null;
         }
 
-        $title = trim(preg_replace('/[\s]+/', ' ', $matches[1]));
+        $title = trim(html_entity_decode(preg_replace('/[\s]+/', ' ', $matches[1])));
 
         if ('' === $title) {
             return null;

--- a/tests/Response/Adapter/SymfonyResponseAdapterTest.php
+++ b/tests/Response/Adapter/SymfonyResponseAdapterTest.php
@@ -93,6 +93,31 @@ CONTENT
     /**
      * @test
      */
+    public function it_returns_encoded_title(): void
+    {
+        $response = new Response(
+            <<<CONTENT
+<!doctype html>
+<html lang="en">
+    <head>
+      <meta charset="utf-8">
+      <title>Great website &amp; what not!</title>
+      <meta name="viewport" content="width=device-width, initial-scale=1">
+    </head>
+    <body>
+      <p>Hello world! This is HTML5 Boilerplate.</p>
+    </body>
+</html>
+CONTENT
+        );
+        $adapter = new SymfonyResponseAdapter($response);
+
+        self::assertSame('Great website & what not!', $adapter->getTitle());
+    }
+
+    /**
+     * @test
+     */
     public function it_checks_for_false(): void
     {
         $response = new class() extends Response {


### PR DESCRIPTION
This PR fixes cases where the `<title>` has encoded characters (see added test for an example)